### PR TITLE
Import reads directly from ftp/http site that user specify

### DIFF
--- a/Proposed product descriptions/Bulk Upload Download.md
+++ b/Proposed product descriptions/Bulk Upload Download.md
@@ -5,7 +5,7 @@
 This will enable upload and download operations on more than one object at a time.
 
 ### Story/Description
-We have recieved many requests for bulk object upload/download operations.  This should be done now as bulk file operations are widely available to users of other web services.  
+We have recieved many requests for bulk object upload/download operations.  This should be done now as bulk file operations are widely available to users of other web services. User can also import reads from a ftp or http site that he/she specify. 
 
 ### User stories
 User 1 would like to upload 100 raw read files.


### PR DESCRIPTION
Hi Dan, 
Uploading of read files directly from ftp/http site is missing there. It is very important to have capability to import read files from a ftp or http url as the read files are in giga bytes and it will help users to directly import the reads from site. Thanks.
Sunita
